### PR TITLE
Ability to write events to a given stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* Ability to write events to a given stream with `Eventum::Client::Events#create`. ([@enriikke][])
+
 ### Changes
 
 * Enable root `Eventum` module to access `streams` and `events` APIs. ([@enriikke][])

--- a/eventum.gemspec
+++ b/eventum.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "virtus", "~> 1.0"
   spec.add_dependency "faraday", "~> 0.9"
+  spec.add_dependency "faraday_middleware", "~> 0.10"
 end

--- a/lib/eventum/api.rb
+++ b/lib/eventum/api.rb
@@ -23,11 +23,10 @@ module Eventum
     # @return [Faraday::Response]
     #
     # @api private
-    def get(path:, body: nil, headers: nil)
+    def get(path:, headers: nil)
       connection.execute(
         method:  :get,
         path:    path,
-        body:    body,
         headers: headers
       )
     end

--- a/lib/eventum/api.rb
+++ b/lib/eventum/api.rb
@@ -17,12 +17,37 @@ module Eventum
     # Executes a GET request on the given path
     #
     # @param path [String] the path of the endpoint to request
+    # @param body [Hash] the body of the post request
+    # @param headers [Hash] the headers of the post request
     #
     # @return [Faraday::Response]
     #
     # @api private
-    def get(path)
-      connection.execute(method: :get, path: path, config: @config)
+    def get(path:, body: nil, headers: nil)
+      connection.execute(
+        method:  :get,
+        path:    path,
+        body:    body,
+        headers: headers
+      )
+    end
+
+    # Executes a POST request on the given path
+    #
+    # @param path [String] the path of the endpoint to request
+    # @param body [Hash] the body of the post request
+    # @param headers [Hash] the headers of the post request
+    #
+    # @return [Faraday::Response]
+    #
+    # @api private
+    def post(path:, body: nil, headers: nil)
+      connection.execute(
+        method:  :post,
+        path:    path,
+        body:    body,
+        headers: headers
+      )
     end
 
     # Points to an {Eventum::Connection} object
@@ -31,7 +56,7 @@ module Eventum
     #
     # @api private
     def connection
-      @connection ||= Eventum::Connection.new
+      @connection ||= Eventum::Connection.new(@config)
     end
   end
 end

--- a/lib/eventum/client/events.rb
+++ b/lib/eventum/client/events.rb
@@ -14,13 +14,34 @@ module Eventum
       #
       # @example
       #   client = Eventum.new
-      #   client.events.find("stream-name", "event-number")
+      #   client.events.find("stream-name", "0")
       #
       # @return [Hash]
       #
       # @api public
       def find(stream, number)
-        get("#{API_PATH}/#{stream}/#{number}")
+        get(path: "#{API_PATH}/#{stream}/#{number}")
+      end
+
+      # Write a new event to the given stream
+      #
+      # @param stream [String] the unique name of the stream
+      # @param type [String] the event type
+      # @param body [Hash] the event data
+      #
+      # @example
+      #   type = "event-type"
+      #   body = { data: "event data" }
+      #
+      #   client = Eventum.new
+      #   client.events.create("stream-name", type: type, body: body)
+      #
+      # @return [Hash]
+      #
+      # @api public
+      def create(stream, type:, body:)
+        headers = { "ES-EventType" => type }
+        post(path: "#{API_PATH}/#{stream}", body: body, headers: headers)
       end
     end
   end

--- a/lib/eventum/client/streams.rb
+++ b/lib/eventum/client/streams.rb
@@ -19,7 +19,7 @@ module Eventum
       #
       # @api public
       def find(name)
-        get("#{API_PATH}/#{name}")
+        get(path: "#{API_PATH}/#{name}")
       end
     end
   end

--- a/lib/eventum/connection.rb
+++ b/lib/eventum/connection.rb
@@ -1,20 +1,41 @@
 require "faraday"
+require "faraday_middleware"
+require "eventum/connection/request"
 
 module Eventum
   # Contains HTTP connection options
+  #
+  # @!attribute [r] request
+  #   An {Eventum::Connection::Request} object
   class Connection
+    attr_reader :request
+
+    # Creates a new intance of {Eventum::Connection}
+    #
+    # @param config [Eventum::Configurable] a configuration object
+    #
+    # @return [Eventum::Connection]
+    #
+    # @api private
+    def initialize(config)
+      @config = config
+    end
+
     # Performs an HTTP request
     #
     # @param method [Symbol] the HTTP method to perform
     # @param path [String] the path of the URL endpoint to request
-    # @param config [Eventum::Configurable] a configuration object
+    # @params body [Hash] the body of the request
+    # @param headers [Hash] the headers of the request
     #
     # @return [Faraday::Response]
     #
     # @api private
-    def execute(method:, path:, config:)
-      conn(config).send(method) do |request|
-        request.url path
+    def execute(method:, path:, body: nil, headers: nil)
+      rebuild_request(method, path, body, headers)
+      conn.send(method) do |props|
+        props.url request.path
+        props.body = request.body
       end
     end
 
@@ -22,16 +43,15 @@ module Eventum
 
     # The HTTP connection object
     #
-    # @param config [Eventum::Configurable] a configuration object
-    #
     # @return [Faraday::Connection]
     #
     # @api private
-    def conn(config)
-      Faraday.new(url: "#{config.host}:#{config.port}") do |faraday|
-        faraday.request :url_encoded
-        faraday.adapter config.adapter
-        faraday.headers = headers
+    def conn
+      Faraday.new(url: request.root_url) do |props|
+        props.use FaradayMiddleware::FollowRedirects, limit: 1
+        props.request :url_encoded
+        props.adapter request.adapter
+        props.headers = request.headers
       end
     end
 
@@ -40,11 +60,31 @@ module Eventum
     # @return [Hash]
     #
     # @api private
-    def headers
+    def default_headers
       {
         ACCEPT:       "application/json".freeze,
         CONTENT_TYPE: "application/json".freeze
       }
+    end
+
+    # Utility method used to rebuild the request on each call
+    #
+    # @param method [Symbol] the HTTP method to perform
+    # @param path [String] the path of the URL endpoint to request
+    # @params body [Hash] the body of the request
+    # @param headers [Hash] the headers of the request
+    #
+    # @return [Eventum::Connection::Request]
+    #
+    # @api private
+    def rebuild_request(method, path, body, headers)
+      @request = Eventum::Connection::Request.new(
+        method:  method,
+        path:    path,
+        body:    body,
+        headers: default_headers.merge(headers.to_h),
+        config:  @config
+      )
     end
   end
 end

--- a/lib/eventum/connection/request.rb
+++ b/lib/eventum/connection/request.rb
@@ -1,0 +1,57 @@
+module Eventum
+  class Connection
+    # Holds properties for a single request
+    #
+    # @!attribute [r] body
+    #   The request body
+    #
+    # @!attribute [r] headers
+    #   The request headers
+    #
+    # @!attribute [r] method
+    #   The request HTTP method
+    #
+    # @!attribute [r] path
+    #   The request endpoint path
+    class Request
+      attr_reader :body, :headers, :method, :path
+
+      # Creates a new {Eventum::Connection::Request} object
+      #
+      # @param method [Symbol] the HTTP method of this request
+      # @param path [String] the path of the request
+      # @param body [Hash] the body of the request
+      # @param headers [Hash] the headers of the request
+      # @param config [Eventum::Configurable] a configuraion object
+      #
+      # @return [Eventum::Connection::Request]
+      #
+      # @api private
+      def initialize(method:, path:, body:, headers:, config:)
+        @method = method
+        @path = path
+        @body = body.to_json
+        @headers = headers
+        @config = config
+      end
+
+      # Returns the root url for this request
+      #
+      # @return [String]
+      #
+      # @api private
+      def root_url
+        @root_url ||= "#{@config.host}:#{@config.port}"
+      end
+
+      # A wrapper to the configurable object adapter
+      #
+      # @return [Symbol]
+      #
+      # @api private
+      def adapter
+        @config.adapter
+      end
+    end
+  end
+end

--- a/spec/cassettes/events/create_invalid_type.yml
+++ b/spec/cassettes/events/create_invalid_type.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://192.168.59.103:2113/streams/awesomeness
+    body:
+      encoding: UTF-8
+      string: '{"eventId":null,"data":{"msg":"I''m an event"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Es-Eventtype:
+      - ''
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Access-Control-Allow-Methods:
+      - POST, DELETE, GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Location:
+      - http://192.168.59.103:2113/streams/awesomeness/incoming/13f08998-e980-455a-b1e8-b5722b048f2d
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 16:17:18 GMT
+      Content-Length:
+      - '28'
+      Keep-Alive:
+      - timeout=15,max=100
+    body:
+      encoding: UTF-8
+      string: Forwarding to idempotent URI
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 16:17:16 GMT
+- request:
+    method: post
+    uri: http://192.168.59.103:2113/streams/awesomeness/incoming/13f08998-e980-455a-b1e8-b5722b048f2d
+    body:
+      encoding: UTF-8
+      string: '{"eventId":null,"data":{"msg":"I''m an event"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Es-Eventtype:
+      - ''
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Empty eventType provided.
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Content-Type:
+      - ''
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 16:17:18 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 16:17:16 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/events/create_nested.yml
+++ b/spec/cassettes/events/create_nested.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://192.168.59.103:2113/streams/awesomeness
+    body:
+      encoding: UTF-8
+      string: '{"title":"Hi World","nested":{"msg":"I''m inside"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Es-Eventtype:
+      - testType
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Access-Control-Allow-Methods:
+      - POST, DELETE, GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Location:
+      - http://192.168.59.103:2113/streams/awesomeness/incoming/81e7d0af-2c45-4cf5-842d-4b65ab993784
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 18:55:11 GMT
+      Content-Length:
+      - '28'
+      Keep-Alive:
+      - timeout=15,max=100
+    body:
+      encoding: UTF-8
+      string: Forwarding to idempotent URI
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 18:55:11 GMT
+- request:
+    method: post
+    uri: http://192.168.59.103:2113/streams/awesomeness/incoming/81e7d0af-2c45-4cf5-842d-4b65ab993784
+    body:
+      encoding: UTF-8
+      string: '{"title":"Hi World","nested":{"msg":"I''m inside"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Es-Eventtype:
+      - testType
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Location:
+      - http://192.168.59.103:2113/streams/awesomeness/2
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 18:55:11 GMT
+      Content-Length:
+      - '0'
+      Keep-Alive:
+      - timeout=15,max=100
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 18:55:11 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/events/create_success.yml
+++ b/spec/cassettes/events/create_success.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://192.168.59.103:2113/streams/awesomeness
+    body:
+      encoding: UTF-8
+      string: '{"eventId":null,"data":{"msg":"I''m an event"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Es-Eventtype:
+      - testType
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 307
+      message: Temporary Redirect
+    headers:
+      Access-Control-Allow-Methods:
+      - POST, DELETE, GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Location:
+      - http://192.168.59.103:2113/streams/awesomeness/incoming/d2a0486a-448a-432a-9fb4-e6c49bc079ce
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 15:25:58 GMT
+      Content-Length:
+      - '28'
+      Keep-Alive:
+      - timeout=15,max=100
+    body:
+      encoding: UTF-8
+      string: Forwarding to idempotent URI
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 15:25:56 GMT
+- request:
+    method: post
+    uri: http://192.168.59.103:2113/streams/awesomeness/incoming/d2a0486a-448a-432a-9fb4-e6c49bc079ce
+    body:
+      encoding: UTF-8
+      string: '{"eventId":null,"data":{"msg":"I''m an event"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Es-Eventtype:
+      - testType
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Location:
+      - http://192.168.59.103:2113/streams/awesomeness/1
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 15:25:58 GMT
+      Content-Length:
+      - '0'
+      Keep-Alive:
+      - timeout=15,max=100
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 15:25:56 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/events/find_invalid_number.yml
+++ b/spec/cassettes/events/find_invalid_number.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://192.168.59.103:2113/streams/awesomeness/X
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: "'X' is not valid event number"
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Content-Type:
+      - ''
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 16:13:26 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 16:13:25 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/events/find_not_found.yml
+++ b/spec/cassettes/events/find_not_found.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://192.168.59.103:2113/streams/awesomeness/1000
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion,
+        ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo,
+        ES-ExpectedVersion
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Location, ES-Position
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Mono-HTTPAPI/1.0
+      Date:
+      - Thu, 10 Sep 2015 16:10:48 GMT
+      Content-Length:
+      - '0'
+      Keep-Alive:
+      - timeout=15,max=100
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 16:10:46 GMT
+recorded_with: VCR 2.9.3

--- a/spec/eventum/client/events_spec.rb
+++ b/spec/eventum/client/events_spec.rb
@@ -17,6 +17,53 @@ RSpec.describe Eventum::Client::Events do
     it { is_expected.to_not be_nil }
     it { expect(subject.status).to eq 200 }
     it { expect(body).to_not be_nil }
+
+    context "when the event doesn't exist" do
+      let(:cassette) { "events/find_not_found" }
+      let(:event) { "1000" }
+
+      it { is_expected.to_not be_nil }
+      it { expect(subject.status).to eq 404 }
+      it { expect(subject.body).to_not be_nil }
+    end
+
+    context "when the event number is invalid" do
+      let(:cassette) { "events/find_invalid_number" }
+      let(:event) { "X" }
+
+      it { is_expected.to_not be_nil }
+      it { expect(subject.status).to eq 400 }
+      it { expect(subject.body).to_not be_nil }
+    end
+  end
+
+  describe "#create" do
+    subject do
+      VCR.use_cassette(cassette, match_requests_on: %i(method path)) do
+        described_class.new(client).create(
+          stream, type: event_type, body: event_data
+        )
+      end
+    end
+
+    let(:body) { JSON.parse(subject.body, symbolize_names: true) }
+    let(:client) { Eventum::Client.new }
+    let(:cassette) { "events/create_success" }
+    let(:stream) { "awesomeness" }
+    let(:event_type) { "testType" }
+    let(:event_data) { { msg: "I'm an event" } }
+
+    it { is_expected.to_not be_nil }
+    it { expect(subject.status).to eq 201 }
+
+    context "when no event type is provided" do
+      let(:cassette) { "events/create_invalid_type" }
+      let(:event_type) { "" }
+
+      it { is_expected.to_not be_nil }
+      it { expect(subject.status).to eq 400 }
+      it { expect(subject.body).to_not be_nil }
+    end
   end
 
   describe "::API_PATH" do

--- a/spec/eventum/client/events_spec.rb
+++ b/spec/eventum/client/events_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe Eventum::Client::Events do
     it { is_expected.to_not be_nil }
     it { expect(subject.status).to eq 201 }
 
+    context "when the event includes nested objects" do
+      let(:cassette) { "events/create_nested" }
+      let(:event_data) { { title: "Hi World", nested: { msg: "I'm inside" } } }
+
+      it { is_expected.to_not be_nil }
+      it { expect(subject.status).to eq 201 }
+    end
+
     context "when no event type is provided" do
       let(:cassette) { "events/create_invalid_type" }
       let(:event_type) { "" }


### PR DESCRIPTION
## Purpose

This PR introduces a new feature that allows clients to write a single event to a given stream.

``` ruby
#################
# Example Usage #
#################

type = "event-type"
body = { data: "event data" }

client = Eventum.new
client.events.create("stream-name", type: type, body: body)
```
## Changes
### 1. Eventum::Client::Events
- Added a `#create` method that can be used to write an event. It requires a `stream name`, `event type`, and the `event body` to be written.
### 2. Eventum::API
- Added a `#post` method that can be consumed by all API clients to send HTTP POST request. It expects a `path` parameter and can optionally take `body` and `headers` values.
### 3. Eventum::Connection::Request
- Introduced a new request object to hold individual HTTP request properties.
